### PR TITLE
Add option to send notifications upon completion of a clue scroll.

### DIFF
--- a/src/main/java/com/discordnotifications/DiscordNotificationsConfig.java
+++ b/src/main/java/com/discordnotifications/DiscordNotificationsConfig.java
@@ -122,6 +122,35 @@ public interface DiscordNotificationsConfig extends Config {
 	}
 	// End death config section
 
+	// Clue config section
+	@ConfigSection(
+			name = "Clue Scrolls",
+			description = "The config for clue scroll notifications",
+			position = 3,
+			closedByDefault = true
+	)
+	String clueConfig = "clueConfig";
+
+	@ConfigItem(
+			keyName = "includeClues",
+			name = "Send Clue Notifications",
+			description = "Send messages when you complete a clue scroll.",
+			section = clueConfig
+	)
+	default boolean sendClue() { return false; }
+
+	@ConfigItem(
+			keyName = "sendClueScreenshot",
+			name = "Include Clue screenshots",
+			description = "Include a screenshot with the discord notification when you complete a clue.",
+			section = clueConfig,
+			position = 100
+	)
+	default boolean sendClueScreenshot() {
+		return false;
+	}
+	// End clue config section
+
 	@ConfigItem(
 			keyName = "webhook",
 			name = "Webhook URL",


### PR DESCRIPTION
Here's a quick little PR which adds the option to send a notification (and screenshot) when a clue scroll is completed. Here's what the notification looks like:
<img width="507" alt="Screenshot 2021-11-11 at 20 56 26" src="https://user-images.githubusercontent.com/6266993/141367941-a6f6fcdb-8149-4c73-b17f-9a51717fad93.png">

Thanks for this plugin - my Group Iron Man have all been using it! 