### PR TITLE
feat: add option to send level notifications based on linear equation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.25'
+def runeLiteVersion = '1.8.2'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/discordnotifications/DiscordNotificationsConfig.java
+++ b/src/main/java/com/discordnotifications/DiscordNotificationsConfig.java
@@ -51,6 +51,17 @@ public interface DiscordNotificationsConfig extends Config {
 	}
 
 	@ConfigItem(
+			keyName = "linearLevelModifier",
+			name = "Linear Level Modifier",
+			description = "Send every `max(-.1x + linearLevelMax, 1)` levels. Will override `Send every X levels` if set to above zero.",
+			section = levellingConfig,
+			position = 4
+	)
+	default double linearLevelMax() {
+		return 0;
+	}
+
+	@ConfigItem(
 			keyName = "sendLevellingScreenshot",
 			name = "Include levelling screenshots",
 			description = "Include a screenshot when leveling up.",

--- a/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
+++ b/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
@@ -181,11 +181,16 @@ public class DiscordNotificationsPlugin extends Plugin
 				&& levelMeetsIntervalRequirement(level);
 	}
 
-	private boolean levelMeetsIntervalRequirement(int level)
-	{
-		return config.levelInterval() <= 1
+	private boolean levelMeetsIntervalRequirement(int level) {
+		int levelInterval = config.levelInterval();
+
+		if (config.linearLevelMax() > 0) {
+			levelInterval = (int) Math.max(Math.ceil(-.1*level + config.linearLevelMax()), 1);
+		}
+
+		return levelInterval <= 1
 				|| level == 99
-				|| level % config.levelInterval() == 0;
+				|| level % levelInterval == 0;
 	}
 
 	private void sendQuestMessage(String questName)


### PR DESCRIPTION
Hi, this is essentially a feature request -- and you can go with what I coded, or come up with another solution if you desire. I agree this solution isn't the most user friendly, but is the best I could come up with in a short amount of time (no xp waste :D).

The idea is that I wanted some "smartness" about which levels I send level notifications for. For lower levels the `Send every X` seems to work well, but for higher level skills, I wouldn't mind sending notifications more often.

For example, if I set `Send every X` to 5, for levels 1-70 or so this seems acceptable. As the levels start to come in more slowly, I find it'd be more acceptable to send notifications every level, or every other level for example. This addition allows you to define which level you'd be okay sending notifications every level.

Here you can see the level (x) vs interval (y) graph of setting the config value to 5
![image](https://user-images.githubusercontent.com/10621463/141697446-e71631df-cddd-4f48-97a9-9bb101ea7561.png)

Here you can see the level vs interval graph of setting the config value to 8:
![image](https://user-images.githubusercontent.com/10621463/141697426-cf50d2e4-cea7-4e5b-8304-e8ec03a02d01.png)

