### PR TITLE
Ignore stat changes that occur on beta worlds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.2'
+def runeLiteVersion = '1.8.5'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
+++ b/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
@@ -135,6 +135,10 @@ public class DiscordNotificationsPlugin extends Plugin
 			return;
 		}
 
+		if (net.runelite.client.config.RuneScapeProfileType.getCurrent(client) == net.runelite.client.config.RuneScapeProfileType.BETA) {
+			return;
+		}
+
 		String skillName = statChanged.getSkill().getName();
 		int level = statChanged.getLevel();
 


### PR DESCRIPTION
Beta worlds tend to allow users to switch their stats to whatever they want, so it doesn't really make sense to hand stat change events when signed onto one.

I went for a quick fix here by just ignoring the stat change events only, since players may still find some value in having deaths broadcast for PvP related betas, but this could also be wrapped behind a configuration value as well.

This also manifested as a bug (that was reported in https://github.com/ATremonte/Discord-Level-Notifications/issues/5) when people would hop worlds to a beta world that any stat that had an associated stat change event emitted would post a message, since cached user levels are only cleared when signing out currently:
https://github.com/WilliamWinterDev/Discord-Notifications/blob/3160660b8738fc0b36585d28cb4659bef35d62e1/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java#L84-L91

![discord-notification-bug](https://user-images.githubusercontent.com/11086936/144648121-51c43d2f-ad29-4b0c-ac28-197865824465.png)

Also any manual level changes done within the beta world could trigger the notification webhook:
![discord-notification-bug2](https://user-images.githubusercontent.com/11086936/144648207-b4c14b5f-81c8-429b-8ae7-d5d2b18572a7.jpg)

Also switching back to a standard world from a beta world would treat those stat changes as level ups as well:
![discord-notification-bug3](https://user-images.githubusercontent.com/11086936/144648332-f57818ab-3418-4a1a-a268-8b7c06f4566c.png)

I haven't tested this change yet since I haven't done any development for RuneLite before, but it seems pretty reasonable at least 🙂 Let me know if there's any sort of validation I should do on my end or any additional changes you'd like to see; thanks for the awesome plugin!

