### PR TITLE
Fix multilevel message sending

### DIFF
--- a/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
+++ b/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
@@ -252,7 +252,7 @@ public class DiscordNotificationsPlugin extends Plugin
 
 	private void sendLevelMessage()
 	{
-		String levelUpString = client.getLocalPlayer().getName();
+		String levelUpString = client.getLocalPlayer().getName() + " leveled ";
 
 		String[] skills = new String[leveledSkills.size()];
 		skills = leveledSkills.toArray(skills);
@@ -266,7 +266,7 @@ public class DiscordNotificationsPlugin extends Plugin
 			{
 				if (i == skills.length - 1)
 				{
-					levelUpString += " and ";
+					levelUpString += ", and ";
 				}
 				else
 				{
@@ -274,7 +274,7 @@ public class DiscordNotificationsPlugin extends Plugin
 				}
 			}
 
-			levelUpString += " leveled " + skill + " to " + currentLevels.get(skill);
+			levelUpString += skill + " to " + currentLevels.get(skill);
 		}
 
 		DiscordWebhookBody discordWebhookBody = new DiscordWebhookBody();

--- a/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
+++ b/src/main/java/com/discordnotifications/DiscordNotificationsPlugin.java
@@ -134,28 +134,35 @@ public class DiscordNotificationsPlugin extends Plugin
 	@Subscribe
 	public void onStatChanged(net.runelite.api.events.StatChanged statChanged)
 	{
-		if (!config.sendLevelling()) {
+		if (!config.sendLevelling())
+		{
 			return;
 		}
 
 		String skillName = statChanged.getSkill().getName();
-		int level = statChanged.getLevel();
+		int newLevel = statChanged.getLevel();
 
 		// .contains wasn't behaving so I went with == null
-		if (currentLevels.get(skillName) == null || currentLevels.get(skillName) == 0)
+		Integer previousLevel = currentLevels.get(skillName);
+		if (previousLevel == null || previousLevel == 0)
 		{
-			currentLevels.put(skillName, level);
+			currentLevels.put(skillName, newLevel);
 			return;
 		}
 
-		if (currentLevels.get(skillName) != level)
+		if (previousLevel != newLevel)
 		{
-			currentLevels.put(skillName, level);
+			currentLevels.put(skillName, newLevel);
 
-			if (shouldSendForThisLevel(level))
+			// Certain activities can multilevel, check if any of the levels are valid for the message.
+			for (int level = previousLevel + 1; level <= newLevel; level++)
 			{
-				leveledSkills.add(skillName);
-				shouldSendLevelMessage = true;
+				if (shouldSendForThisLevel(level))
+				{
+					leveledSkills.add(skillName);
+					shouldSendLevelMessage = true;
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
`shouldSendForThisLevel` is now checked from `previousLevel + 1` to `currentLevel` which allows a level interval of 5 to still send the levelup message when you go from 3 > 8 via a quest when it previously didn't.

Levelup message is also adjusted which fixes an extra space and removes "leveled" being said every time.
```
Name leveled Magic to 20
Name leveled Magic to 20, and Prayer to 5
Name leveled Magic to 20, Prayer to 5, and Strength to 30
```