### PR TITLE
Add minimum clue value configuration option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.5-SNAPSHOT'
+def runeLiteVersion = '1.8.7-SNAPSHOT'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/discordnotifications/DiscordNotificationsConfig.java
+++ b/src/main/java/com/discordnotifications/DiscordNotificationsConfig.java
@@ -146,9 +146,19 @@ public interface DiscordNotificationsConfig extends Config {
 			keyName = "includeClues",
 			name = "Send Clue Notifications",
 			description = "Send messages when you complete a clue scroll.",
-			section = clueConfig
+			section = clueConfig,
+			position = 1
 	)
 	default boolean sendClue() { return false; }
+
+	@ConfigItem(
+			keyName = "minimumClueValue",
+			name = "Minimum Clue Value",
+			description = "Minimum value of clue reward before a notification is sent.",
+			section = clueConfig,
+			position = 2
+	)
+	default int minClueValue() { return 0; }
 
 	@ConfigItem(
 			keyName = "sendClueScreenshot",


### PR DESCRIPTION
To prevent spam from frequent low level clue completions, this PR adds an additional configuration option to add a minimum value threshold for a clue reward casket to meet before it sends a Discord notification.

This change has been tested locally, and the logic for capturing the items from a clue reward and accurately summing the total value of the clue come from the Loot Tracker plugin:

https://github.com/runelite/runelite/blob/8760471818964fed5b8a34010b799d9816b408f4/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java#L580-L581

https://github.com/runelite/runelite/blob/8760471818964fed5b8a34010b799d9816b408f4/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java#L1135-L1145

A further improvement that can be introduced later is also a boolean toggle that allows users to bypass the minimum value threshold if a clue unique is obtained.